### PR TITLE
Allow passing external_tool_url for assignments

### DIFF
--- a/lib/canvas_cc/canvas_cc/assignment_helper.rb
+++ b/lib/canvas_cc/canvas_cc/assignment_helper.rb
@@ -34,5 +34,7 @@ module CanvasCc::CanvasCC::AssignmentHelper
     end
     xml.rubric_use_for_grading assignment.rubric_use_for_grading unless assignment.rubric_use_for_grading.nil?
     xml.rubric_hide_score_total assignment.rubric_hide_score_total unless assignment.rubric_hide_score_total.nil?
+    xml.external_tool_url assignment.external_tool_url if assignment.external_tool_url
+    xml.external_tool_new_tab assignment.external_tool_new_tab if assignment.external_tool_new_tab
   end
 end

--- a/lib/canvas_cc/canvas_cc/models/assignment.rb
+++ b/lib/canvas_cc/canvas_cc/models/assignment.rb
@@ -5,7 +5,7 @@ module CanvasCc::CanvasCC::Models
                   :submission_types, :position, :peer_review_count, :peer_reviews_assigned, :peer_reviews,
                   :automatic_peer_reviews, :grade_group_students_individually, :muted, :turnitin_enabled,
                   :anonymous_peer_reviews, :quiz_identifierref, :rubric, :rubric_use_for_grading, :rubric_hide_score_total,
-                  :grading_standard_identifier_ref, :omit_from_final_grade
+                  :grading_standard_identifier_ref, :omit_from_final_grade, :external_tool_url, :external_tool_new_tab
 
     LAR_TYPE = 'associatedcontent/imscc_xmlv1p1/learning-application-resource'
     ASSIGNMENT_SETTINGS_FILE = 'assignment_settings.xml'

--- a/spec/moodle2cc/canvas_cc/assignment_writer_spec.rb
+++ b/spec/moodle2cc/canvas_cc/assignment_writer_spec.rb
@@ -22,7 +22,7 @@ describe CanvasCc::CanvasCC::AssignmentWriter do
     assignment.points_possible = '30'
     assignment.grading_type = 'points'
     assignment.all_day = 'true'
-    assignment.submission_types = %w(online_text_entry online_url online_upload)
+    assignment.submission_types = %w(online_text_entry online_url online_upload external_tool)
     assignment.position = '2'
     assignment.peer_review_count = '0'
     assignment.peer_reviews_assigned = 'false'
@@ -31,6 +31,8 @@ describe CanvasCc::CanvasCC::AssignmentWriter do
     assignment.grade_group_students_individually = 'false'
     assignment.muted = true
     assignment.quiz_identifierref = 'abc'
+    assignment.external_tool_url = 'http://example.com/lunch'
+    assignment.external_tool_new_tab = true
 
     subject.write
     xml = Nokogiri::XML(File.read(File.join(work_dir, assignment.assignment_resource.files.select{ |f| f.split(//).last(4).join("").to_s == '.xml'}.first)))
@@ -46,7 +48,7 @@ describe CanvasCc::CanvasCC::AssignmentWriter do
     expect(xml.%('assignment/points_possible').text).to eq '30'
     expect(xml.%('assignment/grading_type').text).to eq 'points'
     expect(xml.%('assignment/all_day').text).to eq 'true'
-    expect(xml.%('assignment/submission_types').text).to eq 'online_text_entry,online_url,online_upload'
+    expect(xml.%('assignment/submission_types').text).to eq 'online_text_entry,online_url,online_upload,external_tool'
     expect(xml.%('assignment/position').text).to eq '2'
     expect(xml.%('assignment/peer_review_count').text).to eq '0'
     expect(xml.%('assignment/peer_reviews_assigned').text).to eq 'false'
@@ -55,6 +57,8 @@ describe CanvasCc::CanvasCC::AssignmentWriter do
     expect(xml.%('assignment/grade_group_students_individually').text).to eq 'false'
     expect(xml.%('assignment/muted').text).to eq 'true'
     expect(xml.%('assignment/quiz_identifierref').text).to eq 'abc'
+    expect(xml.%('assignment/external_tool_url').text).to eq 'http://example.com/lunch'
+    expect(xml.%('assignment/external_tool_new_tab').text).to eq 'true'
 
   end
 


### PR DESCRIPTION
Allow to setup external_tool_url and external_tool_new_tab attributes for assignments.

![image](https://user-images.githubusercontent.com/503489/73875857-eb7b4100-4823-11ea-8b65-7ee223d621dd.png)
